### PR TITLE
Update the parser to add a typename selection where required

### DIFF
--- a/Sources/SwiftGraphQLParser/GraphQLDocument.swift
+++ b/Sources/SwiftGraphQLParser/GraphQLDocument.swift
@@ -47,6 +47,14 @@ public struct Field: Equatable {
 	public let arguments: [Argument]
 	public let directives: [Directive]
 	public let selectionSet: [Selection]?
+	
+	static let typename = Field(
+		alias: nil,
+		name: "__typename",
+		arguments: [],
+		directives: [],
+		selectionSet: nil
+	)
 }
 
 public struct Argument: Equatable {


### PR DESCRIPTION
- Move adding `__typename` to the parser from Syrup
- This treats typename as a first class selection instead of appending it as a string in Syrup